### PR TITLE
Simplify output functions

### DIFF
--- a/src/hemsq/hemsq.py
+++ b/src/hemsq/hemsq.py
@@ -105,7 +105,7 @@ class HemsQ:
         
         #制約の重み
         w_cost = 1.0 #コスト項
-        w_d=1.0#需要と供給のバランス 
+        w_d=1.0 #需要と供給のバランス
         w_a=1.0 #項目は一つ割り当てる 
         w_io=1.0 #蓄電池の入出力は同時にしない
         w_s=1.0 #太陽光の収支を合わせる
@@ -114,6 +114,14 @@ class HemsQ:
         result_sche = [] #スケジュールを追加するリスト
         D_all, Sun_all, C_ele_all, C_sun_all =\
              makeInput(sp.demand, sp.tenki, normalize_rate, sp._unit, sp._sell_price) #24時間分のデータ
+        # 出力するデータの作成
+        start = sp.start_time
+        end = sp.start_time + sp.output_len - 1
+        D_op = rotate(start, end, D_all)
+        Sun_op = rotate(start, end, Sun_all)
+        C_ele_op = rotate(start, end, C_ele_all)
+        C_sun_op = rotate(start, end, C_sun_all)
+
         B_0 = int(sp.actual_b_0 / sp.unit)
         B_max = int(sp.actual_b_max / sp.unit)
         rated_capa = int(sp.actual_rated_capa / sp.unit)
@@ -186,17 +194,22 @@ class HemsQ:
         print('Done!')
 
         # 結果とパラメタ OptParamsAndResult の保存
-        self._oprs.append(
-            OptParamsAndResult(
-                copy.copy(sp),
-                normalize_rate,
-                sche_times,
-                D_all,
-                Sun_all,
-                C_ele_all,
-                C_sun_all,
-                result_sche,
-            ))
+        opr = OptParamsAndResult(
+            sp=copy.copy(sp),
+            normalize_rate=normalize_rate,
+            sche_times=sche_times,
+            D_all=D_all,
+            Sun_all=Sun_all,
+            C_ele_all=C_ele_all,
+            C_sun_all=C_sun_all,
+            D_op=D_op,
+            Sun_op=Sun_op,
+            C_ele_op=C_ele_op,
+            C_sun_op=C_sun_op,
+            result_sche=result_sche,
+        )
+        merge_sche(opr)
+        self._oprs.append(opr)
 
     def show_info(self):
         pass
@@ -220,4 +233,4 @@ class HemsQ:
         self.show_supply_and_demand()
         self.show_money_graph()
         opr = self._oprs[-1]
-        marge_sche(opr)
+        output(opr)

--- a/src/hemsq/hemsq.py
+++ b/src/hemsq/hemsq.py
@@ -126,9 +126,12 @@ class HemsQ:
                 B_0 = result_sche[t-1][-1][-1]#前のスケジュール作成の時の蓄電量    
             resche_start = sp.start_time + sp.resche_span * t #リスケ開始時間
             #入力（太陽光・需要・料金）について組み直し開始時間からstep時間分だけ用意する    
-            D_t, Sun_t, C_ele_t, C_sun_t =\
-                rotateAll(resche_start%24, (resche_start + sp.step-1) % 24,\
-                          D_all, Sun_all, C_ele_all, C_sun_all)                
+            start = resche_start % 24
+            end = (resche_start + sp.step-1) % 24
+            D_t = rotate(start, end, D_all)
+            Sun_t = rotate(start, end, Sun_all)
+            C_ele_t = rotate(start, end, C_ele_all)
+            C_sun_t = rotate(start, end, C_sun_all)
             komoku_grp = komokuGroup(D_t, Sun_t, rated_capa, sp.step) #項目の数を決める
             komoku, total = newKomokuProduce(komoku_grp) #項目を作る
             gen = BinarySymbolGenerator()  # BinaryPoly の変数ジェネレータを宣言

--- a/src/hemsq/opt_params_and_result.py
+++ b/src/hemsq/opt_params_and_result.py
@@ -1,13 +1,18 @@
 class OptParamsAndResult:
     def __init__(self,
-            sp,
-            normalize_rate,
-            sche_times,
-            D_all,
-            Sun_all,
-            C_ele_all,
-            C_sun_all,
-            result_sche,
+            sp=None,
+            normalize_rate=None,
+            sche_times=None,
+            D_all=None,
+            Sun_all=None,
+            C_ele_all=None,
+            C_sun_all=None,
+            D_op=None,
+            Sun_op=None,
+            C_ele_op=None,
+            C_sun_op=None,
+            result_sche=None,
+            output_sche=None,
         ):
         self._sp = sp
         self._normalize_rate = normalize_rate
@@ -16,7 +21,39 @@ class OptParamsAndResult:
         self._Sun_all = Sun_all
         self._C_ele_all = C_ele_all
         self._C_sun_all = C_sun_all
+        self._D_op = D_op
+        self._Sun_op = Sun_op
+        self._C_ele_op = C_ele_op
+        self._C_sun_op = C_sun_op
         self._result_sche = result_sche
+        self._output_sche = output_sche
+
+    def set_sp(self, sp):
+        self._sp = sp
+
+    def set_normalize_rate(self, normalize_rate):
+        self._normalize_rate = normalize_rate
+
+    def set_sche_times(self, sche_times):
+        self._sche_times = sche_times
+
+    def set_D_all(self, D_all):
+        self._D_all = D_all
+
+    def set_Sun_all(self, Sun_all):
+        self._Sun_all = Sun_all
+
+    def set_C_ele_all(self, C_ele_all):
+        self._C_ele_all = C_ele_all
+
+    def set_C_sun_all(self, C_sun_all):
+        self._C_sun_all = C_sun_all
+
+    def set_result_sche(self, result_sche):
+        self._result_sche = result_sche
+
+    def set_output_sche(self, output_sche):
+        self._output_sche = output_sche
 
     @property
     def sp(self):
@@ -49,3 +86,7 @@ class OptParamsAndResult:
     @property
     def result_sche(self):
         return self._result_sche
+
+    @property
+    def output_sche(self):
+        return self._output_sche

--- a/src/hemsq/opt_params_and_result.py
+++ b/src/hemsq/opt_params_and_result.py
@@ -49,6 +49,18 @@ class OptParamsAndResult:
     def set_C_sun_all(self, C_sun_all):
         self._C_sun_all = C_sun_all
 
+    def set_D_op(self, D_op):
+        self._D_op = D_op
+
+    def set_Sun_op(self, Sun_op):
+        self._Sun_op = Sun_op
+
+    def set_C_ele_op(self, C_ele_op):
+        self._C_ele_op = C_ele_op
+
+    def set_C_sun_op(self, C_sun_op):
+        self._C_sun_op = C_sun_op
+
     def set_result_sche(self, result_sche):
         self._result_sche = result_sche
 
@@ -82,6 +94,22 @@ class OptParamsAndResult:
     @property
     def C_sun_all(self):
         return self._C_sun_all
+
+    @property
+    def D_op(self):
+        return self._D_op
+
+    @property
+    def Sun_op(self):
+        return self._Sun_op
+
+    @property
+    def C_ele_op(self):
+        return self._C_ele_op
+
+    @property
+    def C_sun_op(self):
+        return self._C_sun_op
 
     @property
     def result_sche(self):

--- a/src/hemsq/sub.py
+++ b/src/hemsq/sub.py
@@ -444,13 +444,13 @@ def plotBar_bat(start, schedule, mode, C_ele, unit, normalize_rate, output_len):
 #グラフ4つ表示
 def makeBar(opr):
     #太陽光の収支
-    plotBar(opr.sp.start, opr.output_sche, opr.Sun_op, 0, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
+    plotBar(opr.sp.start_time, opr.output_sche, opr.Sun_op, 0, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #需要と供給
-    plotBar(opr.sp.start, opr.output_sche, opr.D_op, 1, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
+    plotBar(opr.sp.start_time, opr.output_sche, opr.D_op, 1, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #商用電源料金と充電量
-    plotBar_bat(opr.sp.start, opr.output_sche, 0, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
+    plotBar_bat(opr.sp.start_time, opr.output_sche, 0, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #商用電源料金と使用量
-    plotBar_bat(opr.sp.start, opr.output_sche, 1, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
+    plotBar_bat(opr.sp.start_time, opr.output_sche, 1, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
 
 
 #予測モデル型の場合の出力

--- a/src/hemsq/sub.py
+++ b/src/hemsq/sub.py
@@ -311,7 +311,7 @@ def costPrint(opr):
     e_cost = 0
     for t in range(opr.sp.output_len):
         #商用電源使用は4行目
-        from_ele = (array[4][t] + array[5][t]) * C_ele[t] / opr.normalize_rate 
+        from_ele = (array[4][t] + array[5][t]) * opr.C_ele_op[t] / opr.normalize_rate 
         cost += from_ele
         e_cost += from_ele
         #太陽光売電は2行目

--- a/src/hemsq/sub.py
+++ b/src/hemsq/sub.py
@@ -37,23 +37,17 @@ def my_round(val, digit=0):
     return (val * p * 2 + 1) // 2 / p
 
 
-def rotateAll(start, end, D_all, Sun_all, C_ele_all, C_sun_all):
-    #リストを途中から一周する関数
-    def rotate(start, end, lst):
-        l = len(lst)
-        nlst = [0] * l
-        for i in range(l):
-            if start + i < l:    
-                nlst[i]  = lst[start+i]
-            else:
-                nlst[i] = lst[start+i-l]        
-        nlst = nlst[:end+1-start]
-        return nlst    
-    D = rotate(start, end, D_all)
-    Sun = rotate(start, end, Sun_all)
-    C_ele = rotate(start, end, C_ele_all)
-    C_sun = rotate(start, end, C_sun_all)
-    return D, Sun, C_ele, C_sun
+#リストを途中から一周する関数
+def rotate(start, end, lst):
+    l = len(lst)
+    nlst = [0] * l
+    for i in range(l):
+        if start + i < l:    
+            nlst[i] = lst[start + i]
+        else:
+            nlst[i] = lst[start + i - l]        
+    nlst = nlst[:end + 1 - start]
+    return nlst
 
 
 #24時間分の入力データを作る
@@ -461,16 +455,13 @@ def makeBar(schedule, start, D, Sun, C_ele, unit, normalize_rate, output_len):
 
 #予測モデル型の場合の出力
 def output(opr, schedule):
-    r = opr
+    start_time = opr.sp.start_time
+    end = opr.sp.start_time + opr.sp.output_len - 1
     #outputしたい時間分のデータ
-    D_op, Sun_op, C_ele_op, C_sun_op =\
-        rotateAll(
-            r.sp.start_time,
-            r.sp.start_time + r.sp.output_len - 1,
-            r.D_all,
-            r.Sun_all,
-            r.C_ele_all,
-            r.C_sun_all)
+    D_op = rotate(start_time, end, opr.D_all)
+    Sun_op = rotate(start_time, end, opr.Sun_all)
+    C_ele_op = rotate(start_time, end, opr.C_ele_all)
+    C_sun_op = rotate(start_time, end, opr.C_sun_all)
     #値段表示
     costPrint(
         schedule,

--- a/src/hemsq/sub.py
+++ b/src/hemsq/sub.py
@@ -283,16 +283,16 @@ def makeTable(start, data, labels, mode, output_len):
     plt.show()
 
     
-def make2Table(schedule, start, D, Sun, C_ele, unit, normalize_rate, output_len):
-    demand = list(map(int, normalize(D[:output_len], unit)))
-    sun = list(map(int, normalize(Sun[:output_len], unit)))
-    cost = list(map(int, normalize(C_ele[:output_len], 1000/normalize_rate/unit)))
+def make2Table(opr):
+    demand = list(map(int, normalize(opr.D_op[:opr.sp.output_len], opr.sp.unit)))
+    sun = list(map(int, normalize(opr.Sun_op[:opr.sp.output_len], opr.sp.unit)))
+    cost = list(map(int, normalize(opr.C_ele_op[:opr.sp.output_len], 1000/opr.normalize_rate/opr.sp.unit)))
     label = [
         "Demand (w)",
         "Solar Power Generation (w)",
         "Commercial Electricity Prices (yen)",
     ]
-    makeTable(start, [demand, sun, cost], label, 0, output_len)
+    makeTable(opr.sp.start_time, [demand, sun, cost], label, 0, opr.sp.output_len)
     label = [
         "Use of Solar Power (w)",
         "Charge of Solar Power (w)",
@@ -302,20 +302,20 @@ def make2Table(schedule, start, D, Sun, C_ele, unit, normalize_rate, output_len)
         "Charge of Commercial Electricity (w)",
         "Remaining amount of Battery (w)",
     ]
-    makeTable(start, unitDouble(schedule, normalize_rate, unit), label, 1, output_len)  
+    makeTable(opr.sp.start_time, unitDouble(opr.output_sche, opr.normalize_rate, opr.sp.unit), label, 1, opr.sp.output_len)  
 
 #最適解でかかった経費コストを計上してプリント出力する
-def costPrint(schedule, normalize_rate, C_ele, C_sun, unit, output_len):
-    array = np.array(schedule)
+def costPrint(opr):
+    array = np.array(opr.output_sche)
     cost = 0 #コストの合計
     e_cost = 0
-    for t in range(output_len):
+    for t in range(opr.sp.output_len):
         #商用電源使用は4行目
-        from_ele = (array[4][t] + array[5][t]) * C_ele[t] / normalize_rate 
+        from_ele = (array[4][t] + array[5][t]) * C_ele[t] / opr.normalize_rate 
         cost += from_ele
         e_cost += from_ele
         #太陽光売電は2行目
-        cost -= array[2][t] * C_sun[t] / normalize_rate
+        cost -= array[2][t] * opr.C_sun_op[t] / opr.normalize_rate
     #コスト正なら
     if cost >= 0:
         print("Cost:", cost, "(yen)")
@@ -323,7 +323,7 @@ def costPrint(schedule, normalize_rate, C_ele, C_sun, unit, output_len):
     else:
         print("Sales: ", -cost, "(yen)")
     #CO2排出量（0.445kg/kWh)
-    CO2 = my_round(0.445 * e_cost*unit / 1000, 1)
+    CO2 = my_round(0.445 * e_cost * opr.sp.unit / 1000, 1)
     print("CO2 Emissions:", CO2, "kg")
 
 #棒グラフ
@@ -442,57 +442,28 @@ def plotBar_bat(start, schedule, mode, C_ele, unit, normalize_rate, output_len):
 
 
 #グラフ4つ表示
-def makeBar(schedule, start, D, Sun, C_ele, unit, normalize_rate, output_len):
+def makeBar(opr):
     #太陽光の収支
-    plotBar(start, schedule, Sun, 0, unit, normalize_rate, output_len)
+    plotBar(opr.sp.start, opr.output_sche, opr.Sun_op, 0, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #需要と供給
-    plotBar(start, schedule, D, 1, unit, normalize_rate, output_len)
+    plotBar(opr.sp.start, opr.output_sche, opr.D_op, 1, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #商用電源料金と充電量
-    plotBar_bat(start, schedule, 0, C_ele, unit, normalize_rate, output_len)
+    plotBar_bat(opr.sp.start, opr.output_sche, 0, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
     #商用電源料金と使用量
-    plotBar_bat(start, schedule, 1, C_ele, unit, normalize_rate, output_len)
+    plotBar_bat(opr.sp.start, opr.output_sche, 1, opr.C_ele_op, opr.sp.unit, opr.normalize_rate, opr.sp.output_len)
 
 
 #予測モデル型の場合の出力
-def output(opr, schedule):
-    start_time = opr.sp.start_time
-    end = opr.sp.start_time + opr.sp.output_len - 1
-    #outputしたい時間分のデータ
-    D_op = rotate(start_time, end, opr.D_all)
-    Sun_op = rotate(start_time, end, opr.Sun_all)
-    C_ele_op = rotate(start_time, end, opr.C_ele_all)
-    C_sun_op = rotate(start_time, end, opr.C_sun_all)
+def output(opr):
     #値段表示
-    costPrint(
-        schedule,
-        r.normalize_rate,
-        C_ele_op,
-        C_sun_op,
-        r.sp.unit,
-        r.sp.output_len)
+    costPrint(opr)
     #表表示
-    make2Table(
-        schedule,
-        r.sp.start_time,
-        D_op,
-        Sun_op,
-        C_ele_op,
-        r.sp.unit,
-        r.normalize_rate,
-        r.sp.output_len)
+    make2Table(opr)
     #棒グラフ表示
-    makeBar(
-        schedule,
-        r.sp.start_time,
-        D_op,
-        Sun_op,
-        C_ele_op,
-        r.sp.unit,
-        r.normalize_rate,
-        r.sp.output_len)
+    makeBar(opr)
 
 
-def marge_sche(opr):
+def merge_sche(opr):
     #時間ごとに組み直したスケジュールを24時間にまとめる
     output_sche = []
     for k in range(7):
@@ -501,4 +472,5 @@ def marge_sche(opr):
         for i in range(opr.sche_times):
             b += a[i]
         output_sche.append(b)
-    output(opr, output_sche)
+    opr.set_output_sche(output_sche)
+    return output_sche


### PR DESCRIPTION
Define OptParamsAndResult class so that some output functions only need to take the class object `opr`.